### PR TITLE
Rolling PR for Alces Flight Center naming changes

### DIFF
--- a/builders/flight-cu/config/projects/flight-cu.rb
+++ b/builders/flight-cu/config/projects/flight-cu.rb
@@ -35,7 +35,7 @@ VERSION = '0.1.4'
 override 'charge-client', version: VERSION
 
 build_version VERSION
-build_iteration 1
+build_iteration 2
 
 dependency 'preparation'
 dependency 'charge-client'
@@ -44,7 +44,7 @@ dependency 'version-manifest'
 license 'EPL-2.0'
 license_file 'LICENSE.txt'
 
-description 'Manage Flight Center compute unit balance'
+description 'Manage Alces Flight Center compute unit balance'
 
 exclude '**/.git'
 exclude '**/.gitkeep'

--- a/builders/flight-cu/opt/flight/libexec/commands/cu
+++ b/builders/flight-cu/opt/flight/libexec/commands/cu
@@ -1,6 +1,6 @@
 : '
 : NAME: cu
-: SYNOPSIS: Manage Flight Center compute unit balance
+: SYNOPSIS: Manage Alces Flight Center compute unit balance
 : VERSION: 0.1.4
 : '
 #==============================================================================

--- a/builders/flight-docs/config/projects/flight-docs.rb
+++ b/builders/flight-docs/config/projects/flight-docs.rb
@@ -44,7 +44,7 @@ dependency 'version-manifest'
 license 'EPL-2.0'
 license_file 'LICENSE.txt'
 
-description 'Access your Flight Center documents'
+description 'Access your Alces Flight Center documents'
 
 exclude '**/.git'
 exclude '**/.gitkeep'

--- a/builders/flight-docs/config/projects/flight-docs.rb
+++ b/builders/flight-docs/config/projects/flight-docs.rb
@@ -35,7 +35,7 @@ VERSION = '1.0.1'
 override 'flight-docs', version: VERSION
 
 build_version VERSION
-build_iteration 1
+build_iteration 2
 
 dependency 'preparation'
 dependency 'flight-docs'

--- a/builders/flight-docs/opt/flight/etc/banner/tips.d/40-docs.rc
+++ b/builders/flight-docs/opt/flight/etc/banner/tips.d/40-docs.rc
@@ -5,4 +5,4 @@
 ##
 ################################################################################
 flight_TIP_command="flight docs"
-flight_TIP_synopsis="Access your Flight Center documents"
+flight_TIP_synopsis="Access your Alces Flight Center documents"

--- a/builders/flight-docs/opt/flight/libexec/commands/docs
+++ b/builders/flight-docs/opt/flight/libexec/commands/docs
@@ -1,6 +1,6 @@
 : '
 : NAME: docs
-: SYNOPSIS: Access your Flight Center documents
+: SYNOPSIS: Access your Alces Flight Center documents
 : VERSION: 1.0.1
 : '
 #==============================================================================

--- a/builders/flight-gather/config/projects/flight-gather.rb
+++ b/builders/flight-gather/config/projects/flight-gather.rb
@@ -31,7 +31,7 @@ friendly_name 'Flight Gather'
 
 install_dir '/opt/flight/opt/gather'
 
-VERSION = '1.0.0'
+VERSION = '1.0.1'
 
 build_version VERSION
 build_iteration 1

--- a/builders/flight-gather/libexec/export.sh
+++ b/builders/flight-gather/libexec/export.sh
@@ -30,9 +30,9 @@ usage() {
     prog="flight gather export"
     cat <<USAGE
 Usage: ${prog} [--help] [--dry-run] ASSET_NAME...
-Export inventory data to Flight Center
+Export inventory data to Alces Flight Center
   --help    Display this help text
-  --dry-run Output the asset sheets to a directory, instead of Flight Center
+  --dry-run Output the asset sheets to a directory, instead of Alces Flight Center
 USAGE
 }
 

--- a/builders/flight-gather/libexec/main.sh
+++ b/builders/flight-gather/libexec/main.sh
@@ -26,7 +26,7 @@
 #===============================================================================
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-VERSION='1.0.0'
+VERSION='1.0.1'
 
 usage() {
     local prog
@@ -36,7 +36,7 @@ usage() {
 
     echo "Usage: ${prog} import ASSET_NAME..."
     echo "  or:  ${prog} export ASSET_NAME..."
-    echo "Import inventory data from the cluster and export to Flight Center"
+    echo "Import inventory data from the cluster and export to Alces Flight Center"
 }
 
 main() {

--- a/builders/flight-gather/opt/flight/libexec/commands/gather
+++ b/builders/flight-gather/opt/flight/libexec/commands/gather
@@ -1,7 +1,7 @@
 : '
 : NAME: gather
 : SYNOPSIS: Orchestrate the gathering and exporting inventory data
-: VERSION: 1.0.0
+: VERSION: 1.0.1
 : ROOT: true
 : '
 #==============================================================================

--- a/builders/flight-genders/config/projects/flight-genders.rb
+++ b/builders/flight-genders/config/projects/flight-genders.rb
@@ -31,7 +31,7 @@ friendly_name 'Flight genders'
 
 install_dir '/opt/flight/opt/genders'
 
-VERSION = '1.0.0'
+VERSION = '1.0.1'
 override 'flight-genders', version: VERSION
 
 build_version VERSION
@@ -44,7 +44,7 @@ dependency 'version-manifest'
 license 'EPL-2.0'
 license_file 'LICENSE.txt'
 
-description 'Generate a genders file from Flight Center asset group data'
+description 'Generate a genders file from Alces Flight Center asset group data'
 
 exclude '**/.git'
 exclude '**/.gitkeep'

--- a/builders/flight-genders/config/projects/flight-genders.rb
+++ b/builders/flight-genders/config/projects/flight-genders.rb
@@ -53,6 +53,12 @@ exclude '**/bundler/git'
 extra_package_file "opt/flight/libexec/commands/genders"
 extra_package_file "opt/flight/opt/genders/bin/main.sh"
 
+# Updates the version in the libexec file
+cmd_path = File.expand_path('../../opt/flight/libexec/commands/genders', __dir__)
+cmd = File.read(cmd_path)
+          .sub(/^: VERSION: [[:graph:]]+$/, ": VERSION: #{VERSION}")
+File.write cmd_path, cmd
+
 if ohai['platform_family'] == 'rhel'
   runtime_dependency "flight-asset >= 0.5.0"
 elsif ohai['platform_family'] == 'debian'

--- a/builders/flight-genders/opt/flight/libexec/commands/genders
+++ b/builders/flight-genders/opt/flight/libexec/commands/genders
@@ -1,6 +1,6 @@
 : '
 : NAME: genders
-: SYNOPSIS: Generate a genders file from Flight Center asset group data
+: SYNOPSIS: Generate a genders file from Alces Flight Center asset group data
 : VERSION: 0.1.0
 : '
 #==============================================================================

--- a/builders/flight-genders/opt/flight/libexec/commands/genders
+++ b/builders/flight-genders/opt/flight/libexec/commands/genders
@@ -1,7 +1,7 @@
 : '
 : NAME: genders
 : SYNOPSIS: Generate a genders file from Alces Flight Center asset group data
-: VERSION: 0.1.0
+: VERSION: 1.0.1
 : '
 #==============================================================================
 # Copyright (C) 2020-present Alces Flight Ltd.

--- a/builders/flight-genders/opt/flight/opt/genders/bin/main.sh
+++ b/builders/flight-genders/opt/flight/opt/genders/bin/main.sh
@@ -97,7 +97,7 @@ USAGE:
 
 DESCRIPTION:
 
-  Generate a genders file from Flight Center asset group data.
+  Generate a genders file from Alces Flight Center asset group data.
 
   If FILE is given the results are written to FILE, otherwise to standard
   output.


### PR DESCRIPTION
Publicly FC needs to be referred to as 'Alces Flight Center'. This PR contains updates to various builders with the correct naming. Notable: it does not update `flight-fact` and `flight-asset` as they have been done on different branches